### PR TITLE
Ship support for several data formats by default

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,22 @@ libraries.
 """
 
 [dependencies]
-bytes = "0.4"
-futures-preview = "0.3.0-alpha"
+bytes = "0.5"
+derivative = { version = "1", optional = true }
+futures = "0.3"
 pin-project = "0.4"
+serde = { version = "1", optional = true }
+serde_bincode = { package = "bincode", version = "1", optional = true }
+serde_json = { version = "1", optional = true }
+serde_messagepack = { package = "rmp-serde", version = "0.14", optional = true }
+
+[dev-dependencies]
+tokio = { version = "0.2", features = ["full"] }
+tokio-serde = { path = ".", features = ["bincode", "json", "messagepack"] }
+tokio-util = { version = "0.2", features = ["full"] }
+static_assertions = "1.1.0"
+
+[features]
+bincode = ["derivative", "serde", "serde_bincode"]
+json = ["derivative", "serde", "serde_json"]
+messagepack = ["derivative", "serde", "serde_messagepack"]

--- a/examples/client.rs
+++ b/examples/client.rs
@@ -1,0 +1,30 @@
+use futures::prelude::*;
+use serde_json::json;
+use tokio::net::TcpStream;
+use tokio_serde::formats::*;
+use tokio_util::codec::{FramedWrite, LengthDelimitedCodec};
+
+#[tokio::main]
+pub async fn main() {
+    // Bind a server socket
+    let socket = TcpStream::connect("127.0.0.1:17653").await.unwrap();
+
+    // Delimit frames using a length header
+    let length_delimited = FramedWrite::new(socket, LengthDelimitedCodec::new());
+
+    // Serialize frames with JSON
+    let mut serialized = tokio_serde::FramedWrite::new(length_delimited, Json::default());
+
+    // Send the value
+    serialized
+        .send(json!({
+            "name": "John Doe",
+            "age": 43,
+            "phones": [
+                "+44 1234567",
+                "+44 2345678"
+            ]
+        }))
+        .await
+        .unwrap()
+}

--- a/examples/server.rs
+++ b/examples/server.rs
@@ -1,0 +1,31 @@
+use futures::prelude::*;
+use serde_json::Value;
+use tokio::net::TcpListener;
+use tokio_serde::formats::*;
+use tokio_util::codec::{FramedRead, LengthDelimitedCodec};
+
+#[tokio::main]
+pub async fn main() {
+    // Bind a server socket
+    let mut listener = TcpListener::bind("127.0.0.1:17653").await.unwrap();
+
+    println!("listening on {:?}", listener.local_addr());
+
+    let mut s = listener.incoming();
+
+    while let Some(socket) = s.try_next().await.unwrap() {
+        // Delimit frames using a length header
+        let length_delimited = FramedRead::new(socket, LengthDelimitedCodec::new());
+
+        // Deserialize frames
+        let mut deserialized =
+            tokio_serde::FramedRead::new(length_delimited, Json::<Value>::default());
+
+        // Spawn a task that prints all received messages to STDOUT
+        tokio::spawn(async move {
+            while let Some(msg) = deserialized.try_next().await.unwrap() {
+                println!("GOT: {:?}", msg);
+            }
+        });
+    }
+}


### PR DESCRIPTION
I find there is too much of overlap between tokio-serde-json and tokio-serde-bincode to keep them as separate crates. This PR adds support for several data formats into the crate.