### PR TITLE
Duplex-oriented API

### DIFF
--- a/examples/client.rs
+++ b/examples/client.rs
@@ -13,7 +13,7 @@ pub async fn main() {
     let length_delimited = FramedWrite::new(socket, LengthDelimitedCodec::new());
 
     // Serialize frames with JSON
-    let mut serialized = tokio_serde::FramedWrite::new(length_delimited, Json::default());
+    let mut serialized = tokio_serde::SymmetricallyFramed::new(length_delimited, SymmetricalJson::default());
 
     // Send the value
     serialized

--- a/examples/server.rs
+++ b/examples/server.rs
@@ -19,7 +19,7 @@ pub async fn main() {
 
         // Deserialize frames
         let mut deserialized =
-            tokio_serde::FramedRead::new(length_delimited, Json::<Value>::default());
+            tokio_serde::SymmetricallyFramed::new(length_delimited, SymmetricalJson::<Value>::default());
 
         // Spawn a task that prints all received messages to STDOUT
         tokio::spawn(async move {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -190,188 +190,103 @@ pub trait Deserializer<T> {
     fn deserialize(self: Pin<&mut Self>, src: &BytesMut) -> Result<T, Self::Error>;
 }
 
-/// Adapts a stream of buffers to a stream of values by deserializing them.
-///
-/// It is expected that the buffers yielded by the supplied stream be framed. In
+/// Adapts a transport to a value sink by serializing the values and to a stream of values by deserializing them.
+/// 
+/// It is expected that the buffers yielded by the supplied transport be framed. In
 /// other words, each yielded buffer must represent exactly one serialized
-/// value. The specific framing strategy is left up to the implementor. One option
-/// would be to use [length_delimited] provided by [tokio-io].
+/// value.
 ///
-/// [length_delimited]: http://docs.rs/tokio-io/codec/length_delimited/index.html
-/// [tokio-io]: http://crates.io/crates/tokio-io
-#[pin_project]
-pub struct FramedRead<T, U, S> {
-    #[pin]
-    inner: T,
-    #[pin]
-    deserializer: S,
-    item: PhantomData<U>,
-}
-
-/// Adapts a buffer sink to a value sink by serializing the values.
-///
-/// The provided buffer sink will received buffer values containing the
+/// The provided transport will receive buffer values containing the
 /// serialized value. Each buffer contains exactly one value. This sink will be
 /// responsible for writing these buffers to an `AsyncWrite` using some sort of
-/// framing strategy. The specific framing strategy is left up to the
+/// framing strategy.
+/// 
+/// The specific framing strategy is left up to the
 /// implementor. One option would be to use [length_delimited] provided by
-/// [tokio-io].
+/// [tokio-util].
 ///
-/// [length_delimited]: http://docs.rs/tokio-io/codec/length_delimited/index.html
-/// [tokio-io]: http://crates.io/crates/tokio-io
+/// [length_delimited]: http://docs.rs/tokio-util/codec/length_delimited/index.html
+/// [tokio-util]: http://crates.io/crates/tokio-util
 #[pin_project]
-pub struct FramedWrite<T, U, S> {
+pub struct Framed<Transport, Item, SinkItem, Codec> {
     #[pin]
-    inner: T,
+    inner: Transport,
     #[pin]
-    serializer: S,
-    item: PhantomData<U>,
+    codec: Codec,
+    item: PhantomData<(Item, SinkItem)>,
 }
 
-impl<T, U, S> FramedRead<T, U, S> {
-    /// Creates a new `FramedRead` with the given buffer stream and deserializer.
-    pub fn new(inner: T, deserializer: S) -> FramedRead<T, U, S> {
-        FramedRead {
+impl<Transport, Item, SinkItem, Codec> Framed<Transport, Item, SinkItem, Codec> {
+    /// Creates a new `Framed` with the given transport and codec.
+    pub fn new(inner: Transport, codec: Codec) -> Self {
+        Self {
             inner,
-            deserializer,
+            codec,
             item: PhantomData,
         }
     }
 
-    /// Returns a reference to the underlying stream wrapped by `FramedRead`.
+    /// Returns a reference to the underlying transport wrapped by `Framed`.
     ///
-    /// Note that care should be taken to not tamper with the underlying stream
-    /// of data coming in as it may corrupt the stream of frames otherwise
-    /// being worked with.
-    pub fn get_ref(&self) -> &T {
+    /// Note that care should be taken to not tamper with the underlying transport as
+    /// it may corrupt the sequence of frames otherwise being worked with.
+    pub fn get_ref(&self) -> &Transport {
         &self.inner
     }
 
-    /// Returns a mutable reference to the underlying stream wrapped by
-    /// `FramedRead`.
+    /// Returns a mutable reference to the underlying transport wrapped by
+    /// `Framed`.
     ///
-    /// Note that care should be taken to not tamper with the underlying stream
-    /// of data coming in as it may corrupt the stream of frames otherwise
-    /// being worked with.
-    pub fn get_mut(&mut self) -> &mut T {
+    /// Note that care should be taken to not tamper with the underlying transport as
+    /// it may corrupt the sequence of frames otherwise being worked with.
+    pub fn get_mut(&mut self) -> &mut Transport {
         &mut self.inner
     }
 
-    /// Consumes the `FramedRead`, returning its underlying stream.
+    /// Consumes the `Framed`, returning its underlying transport.
     ///
-    /// Note that care should be taken to not tamper with the underlying stream
-    /// of data coming in as it may corrupt the stream of frames otherwise being
-    /// worked with.
-    pub fn into_inner(self) -> T {
+    /// Note that care should be taken to not tamper with the underlying transport as
+    /// it may corrupt the sequence of frames otherwise being worked with.
+    pub fn into_inner(self) -> Transport {
         self.inner
     }
 }
 
-impl<T, U, S> Stream for FramedRead<T, U, S>
+impl<Transport, Item, SinkItem, Codec> Stream for Framed<Transport, Item, SinkItem, Codec>
 where
-    T: TryStream<Ok = BytesMut>,
-    T::Error: From<S::Error>,
-    BytesMut: From<T::Ok>,
-    S: Deserializer<U>,
+    Transport: TryStream<Ok = BytesMut>,
+    Transport::Error: From<Codec::Error>,
+    BytesMut: From<Transport::Ok>,
+    Codec: Deserializer<Item>,
 {
-    type Item = Result<U, T::Error>;
+    type Item = Result<Item, Transport::Error>;
 
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         match ready!(self.as_mut().project().inner.try_poll_next(cx)) {
             Some(bytes) => Poll::Ready(Some(Ok(self
                 .as_mut()
                 .project()
-                .deserializer
+                .codec
                 .deserialize(&bytes?)?))),
             None => Poll::Ready(None),
         }
     }
 }
 
-impl<T, U, S, SinkItem> Sink<SinkItem> for FramedRead<T, U, S>
+impl<Transport, Item, SinkItem, Codec> Sink<SinkItem> for Framed<Transport, Item, SinkItem, Codec>
 where
-    T: Sink<SinkItem>,
+    Transport: Sink<Bytes>,
+    Codec: Serializer<SinkItem>,
+    Codec::Error: Into<Transport::Error>,
 {
-    type Error = T::Error;
+    type Error = Transport::Error;
 
     fn poll_ready(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
         self.project().inner.poll_ready(cx)
     }
 
-    fn start_send(self: Pin<&mut Self>, item: SinkItem) -> Result<(), Self::Error> {
-        self.project().inner.start_send(item)
-    }
-
-    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
-        self.project().inner.poll_flush(cx)
-    }
-
-    fn poll_close(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
-        self.project().inner.poll_close(cx)
-    }
-}
-
-impl<T, U, S> FramedWrite<T, U, S> {
-    /// Creates a new `FramedWrite` with the given buffer sink and serializer.
-    pub fn new(inner: T, serializer: S) -> Self {
-        FramedWrite {
-            inner,
-            serializer,
-            item: PhantomData,
-        }
-    }
-
-    /// Returns a reference to the underlying sink wrapped by `FramedWrite`.
-    ///
-    /// Note that care should be taken to not tamper with the underlying sink as
-    /// it may corrupt the sequence of frames otherwise being worked with.
-    pub fn get_ref(&self) -> &T {
-        &self.inner
-    }
-
-    /// Returns a mutable reference to the underlying sink wrapped by
-    /// `FramedWrite`.
-    ///
-    /// Note that care should be taken to not tamper with the underlying sink as
-    /// it may corrupt the sequence of frames otherwise being worked with.
-    pub fn get_mut(&mut self) -> &mut T {
-        &mut self.inner
-    }
-
-    /// Consumes the `FramedWrite`, returning its underlying sink.
-    ///
-    /// Note that care should be taken to not tamper with the underlying sink as
-    /// it may corrupt the sequence of frames otherwise being worked with.
-    pub fn into_inner(self) -> T {
-        self.inner
-    }
-}
-
-impl<T, U, S> Stream for FramedWrite<T, U, S>
-where
-    T: Stream,
-{
-    type Item = T::Item;
-
-    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-        self.project().inner.poll_next(cx)
-    }
-}
-
-impl<T, U, S> Sink<U> for FramedWrite<T, U, S>
-where
-    T: Sink<Bytes>,
-    S: Serializer<U>,
-    S::Error: Into<T::Error>,
-{
-    type Error = T::Error;
-
-    fn poll_ready(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
-        self.project().inner.poll_ready(cx)
-    }
-
-    fn start_send(mut self: Pin<&mut Self>, item: U) -> Result<(), Self::Error> {
-        let res = self.as_mut().project().serializer.serialize(&item);
+    fn start_send(mut self: Pin<&mut Self>, item: SinkItem) -> Result<(), Self::Error> {
+        let res = self.as_mut().project().codec.serialize(&item);
         let bytes = res.map_err(Into::into)?;
 
         self.as_mut().project().inner.start_send(bytes)?;
@@ -389,14 +304,16 @@ where
     }
 }
 
+pub type SymmetricallyFramed<Transport, Value, Codec> = Framed<Transport, Value, Value, Codec>;
+
 #[cfg(any(feature = "json", feature = "bincode", feature = "messagepack"))]
 pub mod formats {
     #[cfg(feature = "bincode")]
-    pub use self::bincode::Bincode;
+    pub use self::bincode::*;
     #[cfg(feature = "json")]
-    pub use self::json::Json;
+    pub use self::json::*;
     #[cfg(feature = "messagepack")]
-    pub use self::messagepack::MessagePack;
+    pub use self::messagepack::*;
 
     use {
         super::{Deserializer, Serializer},
@@ -412,34 +329,36 @@ pub mod formats {
 
         #[derive(Derivative)]
         #[derivative(Default(bound = ""))]
-        pub struct Bincode<T> {
-            ghost: PhantomData<T>,
+        pub struct Bincode<Item, SinkItem> {
+            ghost: PhantomData<(Item, SinkItem)>,
         }
 
-        impl<T> Deserializer<T> for Bincode<T>
+        impl<Item, SinkItem> Deserializer<Item> for Bincode<Item, SinkItem>
         where
-            T: for<'de> Deserialize<'de>,
+            for<'a> Item: Deserialize<'a>,
         {
             type Error = io::Error;
 
-            fn deserialize(self: Pin<&mut Self>, src: &BytesMut) -> Result<T, Self::Error> {
+            fn deserialize(self: Pin<&mut Self>, src: &BytesMut) -> Result<Item, Self::Error> {
                 Ok(serde_bincode::deserialize(src)
                     .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?)
             }
         }
 
-        impl<T> Serializer<T> for Bincode<T>
+        impl<Item, SinkItem> Serializer<SinkItem> for Bincode<Item, SinkItem>
         where
-            T: Serialize,
+            SinkItem: Serialize,
         {
             type Error = io::Error;
 
-            fn serialize(self: Pin<&mut Self>, item: &T) -> Result<Bytes, Self::Error> {
+            fn serialize(self: Pin<&mut Self>, item: &SinkItem) -> Result<Bytes, Self::Error> {
                 Ok(serde_bincode::serialize(item)
                     .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?
                     .into())
             }
         }
+
+        pub type SymmetricalBincode<T> = Bincode<T, T>;
     }
 
     #[cfg(feature = "json")]
@@ -448,31 +367,33 @@ pub mod formats {
 
         #[derive(Derivative)]
         #[derivative(Default(bound = ""))]
-        pub struct Json<T> {
-            ghost: PhantomData<T>,
+        pub struct Json<Item, SinkItem> {
+            ghost: PhantomData<(Item, SinkItem)>,
         }
 
-        impl<T> Deserializer<T> for Json<T>
+        impl<Item, SinkItem> Deserializer<Item> for Json<Item, SinkItem>
         where
-            for<'a> T: Deserialize<'a>,
+            for<'a> Item: Deserialize<'a>,
         {
             type Error = serde_json::Error;
 
-            fn deserialize(self: Pin<&mut Self>, src: &BytesMut) -> Result<T, Self::Error> {
+            fn deserialize(self: Pin<&mut Self>, src: &BytesMut) -> Result<Item, Self::Error> {
                 serde_json::from_reader(std::io::Cursor::new(src).reader())
             }
         }
 
-        impl<T> Serializer<T> for Json<T>
+        impl<Item, SinkItem> Serializer<SinkItem> for Json<Item, SinkItem>
         where
-            T: Serialize,
+            SinkItem: Serialize,
         {
             type Error = serde_json::Error;
 
-            fn serialize(self: Pin<&mut Self>, item: &T) -> Result<Bytes, Self::Error> {
+            fn serialize(self: Pin<&mut Self>, item: &SinkItem) -> Result<Bytes, Self::Error> {
                 serde_json::to_vec(item).map(Into::into)
             }
         }
+
+        pub type SymmetricalJson<T> = Json<T, T>;
     }
 
     #[cfg(feature = "messagepack")]
@@ -483,17 +404,17 @@ pub mod formats {
 
         #[derive(Derivative)]
         #[derivative(Default(bound = ""))]
-        pub struct MessagePack<T> {
-            ghost: PhantomData<T>,
+        pub struct MessagePack<Item, SinkItem> {
+            ghost: PhantomData<(Item, SinkItem)>,
         }
 
-        impl<T> Deserializer<T> for MessagePack<T>
+        impl<Item, SinkItem> Deserializer<Item> for MessagePack<Item, SinkItem>
         where
-            for<'a> T: Deserialize<'a>,
+            for<'a> Item: Deserialize<'a>,
         {
             type Error = io::Error;
 
-            fn deserialize(self: Pin<&mut Self>, src: &BytesMut) -> Result<T, Self::Error> {
+            fn deserialize(self: Pin<&mut Self>, src: &BytesMut) -> Result<Item, Self::Error> {
                 Ok(
                     serde_messagepack::from_read(std::io::Cursor::new(src).reader())
                         .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?,
@@ -501,17 +422,19 @@ pub mod formats {
             }
         }
 
-        impl<T> Serializer<T> for MessagePack<T>
+        impl<Item, SinkItem> Serializer<SinkItem> for MessagePack<Item, SinkItem>
         where
-            T: Serialize,
+            SinkItem: Serialize,
         {
             type Error = io::Error;
 
-            fn serialize(self: Pin<&mut Self>, item: &T) -> Result<Bytes, Self::Error> {
+            fn serialize(self: Pin<&mut Self>, item: &SinkItem) -> Result<Bytes, Self::Error> {
                 Ok(serde_messagepack::to_vec(item)
                     .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?
                     .into())
             }
         }
+
+        pub type SymmetricalMessagePack<T> = MessagePack<T, T>;
     }
 }


### PR DESCRIPTION
This API introduces major changes to this crate's API with one sole goal: ease writing duplex transports. This is something that I encountered while making google/tarpc#274. I found it very burdensome to make a duplex transport with same codec but different ins and outs.

# What has changed
- `FramedRead` and `FramedWrite` united into a single `Framed`. Since `Stream` and `Sink` impls depend on the presence of inner transport's `Stream` and `Sink` anyway, it just doesn't make any sense to keep separate types.
- Codecs have both `Item` and `SinkItem` types now with adapters for symmetrical serialisation (`Item` = `SinkItem`).