### PR TITLE
Feature/cbor

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ serde = { version = "1", optional = true }
 bincode-crate = { package = "bincode", version = "1", optional = true }
 serde_json = { version = "1", optional = true }
 rmp-serde = { version = "0.14", optional = true }
-serde_cbor = { version = "0.11.1", optional = true }
+serde_cbor = { version = "0.11.*", optional = true }
 
 [dev-dependencies]
 tokio = { version = "0.2", features = ["full"] }
@@ -44,8 +44,8 @@ cbor = ["serde", "serde_cbor"]
 
 [[example]]
 name = "client"
-required-features = ["bincode", "json", "messagepack"]
+required-features = ["bincode", "json", "messagepack", "cbor"]
 
 [[example]]
 name = "server"
-required-features = ["bincode", "json", "messagepack"]
+required-features = ["bincode", "json", "messagepack", "cbor"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ serde = { version = "1", optional = true }
 bincode-crate = { package = "bincode", version = "1", optional = true }
 serde_json = { version = "1", optional = true }
 rmp-serde = { version = "0.14", optional = true }
+serde_cbor = { version = "0.11.1", optional = true }
 
 [dev-dependencies]
 tokio = { version = "0.2", features = ["full"] }
@@ -39,6 +40,7 @@ static_assertions = "1.1.0"
 bincode = ["derivative", "serde", "bincode-crate"]
 json = ["derivative", "serde", "serde_json"]
 messagepack = ["derivative", "serde", "rmp-serde"]
+cbor = ["serde", "serde_cbor"]
 
 [[example]]
 name = "client"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ serde = { version = "1", optional = true }
 bincode-crate = { package = "bincode", version = "1", optional = true }
 serde_json = { version = "1", optional = true }
 rmp-serde = { version = "0.14", optional = true }
-serde_cbor = { version = "0.11.*", optional = true }
+serde_cbor = { version = "0.11", optional = true }
 
 [dev-dependencies]
 tokio = { version = "0.2", features = ["full"] }
@@ -44,8 +44,8 @@ cbor = ["serde", "serde_cbor"]
 
 [[example]]
 name = "client"
-required-features = ["bincode", "json", "messagepack", "cbor"]
+required-features = ["bincode", "cbor", "json", "messagepack"]
 
 [[example]]
 name = "server"
-required-features = ["bincode", "json", "messagepack", "cbor"]
+required-features = ["bincode", "cbor", "json", "messagepack"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -459,7 +459,8 @@ pub mod formats {
 
         /// CBOR codec using [serde_cbor](https://docs.rs/serde_cbor) crate.
         #[cfg_attr(feature = "docs", doc(cfg(cbor)))]
-        #[derive(Default)]
+        #[derive(Derivative)]
+        #[derivative(Default(bound = ""))]
         pub struct Cbor<Item, SinkItem> {
             _mkr: PhantomData<(Item, SinkItem)>,
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -316,6 +316,8 @@ pub type SymmetricallyFramed<Transport, Value, Codec> = Framed<Transport, Value,
 pub mod formats {
     #[cfg(feature = "bincode")]
     pub use self::bincode::*;
+    #[cfg(feature = "cbor")]
+    pub use self::cbor::*;
     #[cfg(feature = "json")]
     pub use self::json::*;
     #[cfg(feature = "messagepack")]
@@ -447,6 +449,56 @@ pub mod formats {
                 Ok(rmp_serde::to_vec(item)
                     .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?
                     .into())
+            }
+        }
+    }
+
+    #[cfg(feature = "cbor")]
+    mod cbor {
+        use super::*;
+
+        /// CBOR codec using [serde_cbor](https://docs.rs/serde_cbor) crate.
+        #[cfg_attr(feature = "docs", doc(cfg(cbor)))]
+        #[derive(Default)]
+        pub struct Cbor<Item, SinkItem> {
+            _mkr: PhantomData<(Item, SinkItem)>,
+        }
+
+        #[cfg_attr(feature = "docs", doc(cfg(cbor)))]
+        pub type SymmetricalCbor<T> = Cbor<T, T>;
+
+        impl<Item, SinkItem> Deserializer<Item> for Cbor<Item, SinkItem>
+        where
+            for<'a> Item: Deserialize<'a>,
+        {
+            type Error = io::Error;
+
+            fn deserialize(self: Pin<&mut Self>, src: &BytesMut) -> Result<Item, Self::Error> {
+                serde_cbor::from_slice(src.as_ref()).map_err(|e| into_io_error(e))
+            }
+        }
+
+        impl<Item, SinkItem> Serializer<SinkItem> for Cbor<Item, SinkItem>
+        where
+            SinkItem: Serialize,
+        {
+            type Error = io::Error;
+
+            fn serialize(self: Pin<&mut Self>, item: &SinkItem) -> Result<Bytes, Self::Error> {
+                serde_cbor::to_vec(item)
+                    .map_err(|e| into_io_error(e))
+                    .map(Into::into)
+            }
+        }
+
+        fn into_io_error(cbor_err: serde_cbor::Error) -> io::Error {
+            use {io::ErrorKind, serde_cbor::error::Category};
+
+            match cbor_err.classify() {
+                Category::Eof => io::Error::new(ErrorKind::UnexpectedEof, cbor_err),
+                Category::Syntax => io::Error::new(ErrorKind::InvalidInput, cbor_err),
+                Category::Data => io::Error::new(ErrorKind::InvalidData, cbor_err),
+                Category::Io => io::Error::new(ErrorKind::Other, cbor_err),
             }
         }
     }


### PR DESCRIPTION
Added a `cbor` module to `formats` containing `Cbor` and `SymmetricalCbor` structs and the associated De/Serializer trait impls, using [serde_cbor](https://docs.rs/serde_cbor) as the backing lib. I've followed what appears to be the convention of using an `io:Error` for the associated error type. 