### PR TITLE
Remove dependency on derivative crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,6 @@ libraries.
 
 [dependencies]
 bytes = "0.5"
-derivative = { version = "1", optional = true }
 futures = "0.3"
 pin-project = "0.4"
 serde = { version = "1", optional = true }
@@ -36,9 +35,9 @@ tokio-util = { version = "0.2", features = ["full"] }
 static_assertions = "1.1.0"
 
 [features]
-bincode = ["derivative", "serde", "bincode-crate"]
-json = ["derivative", "serde", "serde_json"]
-messagepack = ["derivative", "serde", "rmp-serde"]
+bincode = ["serde", "bincode-crate"]
+json = ["serde", "serde_json"]
+messagepack = ["serde", "rmp-serde"]
 
 [[example]]
 name = "client"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -324,7 +324,6 @@ pub mod formats {
     use {
         super::{Deserializer, Serializer},
         bytes::{buf::BufExt, Bytes, BytesMut},
-        derivative::Derivative,
         serde::{Deserialize, Serialize},
         std::{io, marker::PhantomData, pin::Pin},
     };
@@ -335,14 +334,18 @@ pub mod formats {
 
         /// Bincode codec using [bincode](https://docs.rs/bincode) crate.
         #[cfg_attr(feature = "docs", doc(cfg(bincode)))]
-        #[derive(Derivative)]
-        #[derivative(Default(bound = ""))]
         pub struct Bincode<Item, SinkItem> {
             ghost: PhantomData<(Item, SinkItem)>,
         }
 
         #[cfg_attr(feature = "docs", doc(cfg(bincode)))]
         pub type SymmetricalBincode<T> = Bincode<T, T>;
+
+        impl<Item, SinkItem> Default for Bincode<Item, SinkItem> {
+            fn default() -> Self {
+                Bincode { ghost: PhantomData }
+            }
+        }
 
         impl<Item, SinkItem> Deserializer<Item> for Bincode<Item, SinkItem>
         where
@@ -376,14 +379,18 @@ pub mod formats {
 
         /// JSON codec using [serde_json](https://docs.rs/serde_json) crate.
         #[cfg_attr(feature = "docs", doc(cfg(json)))]
-        #[derive(Derivative)]
-        #[derivative(Default(bound = ""))]
         pub struct Json<Item, SinkItem> {
             ghost: PhantomData<(Item, SinkItem)>,
         }
 
         #[cfg_attr(feature = "docs", doc(cfg(json)))]
         pub type SymmetricalJson<T> = Json<T, T>;
+
+        impl<Item, SinkItem> Default for Json<Item, SinkItem> {
+            fn default() -> Self {
+                Json { ghost: PhantomData }
+            }
+        }
 
         impl<Item, SinkItem> Deserializer<Item> for Json<Item, SinkItem>
         where
@@ -416,14 +423,18 @@ pub mod formats {
 
         /// MessagePack codec using [rmp-serde](https://docs.rs/rmp-serde) crate.
         #[cfg_attr(feature = "docs", doc(cfg(messagepack)))]
-        #[derive(Derivative)]
-        #[derivative(Default(bound = ""))]
         pub struct MessagePack<Item, SinkItem> {
             ghost: PhantomData<(Item, SinkItem)>,
         }
 
         #[cfg_attr(feature = "docs", doc(cfg(messagepack)))]
         pub type SymmetricalMessagePack<T> = MessagePack<T, T>;
+
+        impl<Item, SinkItem> Default for MessagePack<Item, SinkItem> {
+            fn default() -> Self {
+                MessagePack { ghost: PhantomData }
+            }
+        }
 
         impl<Item, SinkItem> Deserializer<Item> for MessagePack<Item, SinkItem>
         where


### PR DESCRIPTION
Hey @vorot93, what do you think of this? Thanks for maintaining this crate, by the way—it's simple but so useful!

----

The derivative crate is a heavyweight dependency, and one that is
relatively unmaintained: its last release was eight months ago, and it
is one of the few crates in the ecosystem that still depends upon
pre-1.0 syn, quote, and proc-macro2.

In the interest of keeping tokio-serde lightweight, and in the spirit of
[0], I think it makes more sense to simply add the correct Default
implementations by hand, rather than pulling in all of derivative.

[0]: https://raphlinus.github.io/rust/2019/08/21/rust-bloat.html