### PR TITLE
Enable formats mod for cbor feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ static_assertions = "1.1.0"
 bincode = ["derivative", "serde", "bincode-crate"]
 json = ["derivative", "serde", "serde_json"]
 messagepack = ["derivative", "serde", "rmp-serde"]
-cbor = ["serde", "serde_cbor"]
+cbor = ["derivative", "serde", "serde_cbor"]
 
 [[example]]
 name = "client"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -306,10 +306,20 @@ where
 
 pub type SymmetricallyFramed<Transport, Value, Codec> = Framed<Transport, Value, Value, Codec>;
 
-#[cfg(any(feature = "json", feature = "bincode", feature = "messagepack"))]
+#[cfg(any(
+    feature = "json",
+    feature = "bincode",
+    feature = "messagepack",
+    feature = "cbor"
+))]
 #[cfg_attr(
     docs,
-    doc(cfg(any(feature = "json", feature = "bincode", feature = "messagepack")))
+    doc(cfg(any(
+        feature = "json",
+        feature = "bincode",
+        feature = "messagepack",
+        feature = "cbor"
+    )))
 )]
 pub mod formats {
     #[cfg(feature = "bincode")]


### PR DESCRIPTION
Otherwise if compiled with only `--features cbor` the `Cbor` format would be missing.