### PR TITLE
trivial refactoring  --- fails, types are really complex to figure out

### DIFF
--- a/examples/client.rs
+++ b/examples/client.rs
@@ -4,17 +4,23 @@ use tokio::net::TcpStream;
 use tokio_serde::formats::*;
 use tokio_util::codec::{FramedWrite, LengthDelimitedCodec};
 
+fn setup_writer(socket: tokio::net::TcpStream) -> impl Sink<serde_json::Value> {
+    // Delimit frames using a length header
+    let length_delimited = FramedWrite::new(socket, LengthDelimitedCodec::new());
+
+    // Serialize frames with JSON
+    let serialized =
+        tokio_serde::SymmetricallyFramed::new(length_delimited, SymmetricalJson::default());
+
+    return serialized;
+}
+
 #[tokio::main]
 pub async fn main() {
     // Bind a server socket
     let socket = TcpStream::connect("127.0.0.1:17653").await.unwrap();
 
-    // Delimit frames using a length header
-    let length_delimited = FramedWrite::new(socket, LengthDelimitedCodec::new());
-
-    // Serialize frames with JSON
-    let mut serialized =
-        tokio_serde::SymmetricallyFramed::new(length_delimited, SymmetricalJson::default());
+    let mut serialized = setup_writer(socket);
 
     // Send the value
     serialized


### PR DESCRIPTION
Hi, this may be a dumb way to ask for help: via a pull request which does not compile.
Once I/we figure out why it doesn't work, and we fix it, it would be nice if it could be accepted so that others could benefit more from the examples.  (actually, my example uses Cbor encoding, which I'd like to add as a second example).

As you can see, I've done what I think is a trivial refactoring.  @pie_flavour on Discord suggested that I should be using "impl Sink<>", and I realised that it needed to take the thing going in (JSON), not the thing coming out the bottom (bytes).

Probably there is something else that the return value needs to add to it, but I don't know what.

````
obiwan-[pandora/connect/tokio-serde](2.6.6) mcr 18190 %cargo build --features "bincode cbor json messagepack" --example client
   Compiling tokio-serde v0.7.1 (/ssw/projects/pandora/connect/tokio-serde)
error[E0599]: no method named `unwrap` found for enum `std::result::Result<(), <impl futures::Sink<serde_json::Value> as futures::Sink<serde_json::Value>>::Error>` in the current scope
  --> examples/client.rs:36:10
   |
36 |         .unwrap()
   |          ^^^^^^ method not found in `std::result::Result<(), <impl futures::Sink<serde_json::Value> as futures::Sink<serde_json::Value>>::Error>`
   |
   = note: the method `unwrap` exists but the following trait bounds were not satisfied:
           `<impl futures::Sink<serde_json::Value> as futures::Sink<serde_json::Value>>::Error: std::fmt::Debug`

error: aborting due to previous error

For more information about this error, try `rustc --explain E0599`.
error: could not compile `tokio-serde`.

To learn more, run the command again with --verbose.
````

