### PR TITLE
Bump tokio to 1.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ libraries.
 """
 
 [dependencies]
-bytes = "0.6"
+bytes = "1.0"
 educe = { version = "0.4", optional = true, default-features = false }
 futures-core = "0.3"
 futures-sink = "0.3"
@@ -36,8 +36,8 @@ serde_cbor = { version = "0.11", optional = true }
 [dev-dependencies]
 futures = "0.3"
 impls = "1"
-tokio = { version = "0.3", features = ["full"] }
-tokio-util = { version = "0.5", features = ["codec"] }
+tokio = { version = "1.0", features = ["full"] }
+tokio-util = { version = "0.6", features = ["codec"] }
 static_assertions = "1.1.0"
 
 [package.metadata.docs.rs]

--- a/examples/server.rs
+++ b/examples/server.rs
@@ -7,11 +7,13 @@ use tokio_util::codec::{FramedRead, LengthDelimitedCodec};
 #[tokio::main]
 pub async fn main() {
     // Bind a server socket
-    let mut listener = TcpListener::bind("127.0.0.1:17653").await.unwrap();
+    let listener = TcpListener::bind("127.0.0.1:17653").await.unwrap();
 
     println!("listening on {:?}", listener.local_addr());
 
-    while let Some(socket) = listener.try_next().await.unwrap() {
+    loop {
+        let (socket, _) = listener.accept().await.unwrap();
+
         // Delimit frames using a length header
         let length_delimited = FramedRead::new(socket, LengthDelimitedCodec::new());
 


### PR DESCRIPTION
This will allow [`tarpc`](https://github.com/google/tarpc/pull/337) (among many other crates) to update to `tokio 1.0.0` as well.