### PR TITLE
Add reading and writing example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,3 +57,7 @@ required-features = ["bincode", "cbor", "json", "messagepack"]
 [[example]]
 name = "server"
 required-features = ["bincode", "cbor", "json", "messagepack"]
+
+[[example]]
+name = "duplex"
+required-features = ["bincode", "cbor", "json", "messagepack", "serde/derive"]

--- a/examples/duplex.rs
+++ b/examples/duplex.rs
@@ -1,0 +1,72 @@
+use futures::prelude::*;
+use serde::{Deserialize, Serialize};
+use tokio::net::{TcpListener, TcpStream};
+use tokio_serde::formats::*;
+use tokio_util::codec::{Framed, LengthDelimitedCodec};
+
+#[derive(Debug, Serialize, Deserialize)]
+enum Request {
+    Hello(String),
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+enum Response {
+    Greeting(String),
+}
+
+pub async fn server(name: &'static str) {
+    let listener = TcpListener::bind("127.0.0.1:17653").await.unwrap();
+
+    loop {
+        let (socket, _) = listener.accept().await.unwrap();
+
+        // Delimit frames using a length header
+        let length_delimited = Framed::new(socket, LengthDelimitedCodec::new());
+
+        // Serialize and deserialize frames with JSON
+        let mut stream: tokio_serde::Framed<_, Request, Response, _> =
+            tokio_serde::Framed::new(length_delimited, Json::<Request, Response>::default());
+
+        tokio::spawn(async move {
+            while let Some(msg) = stream.try_next().await.unwrap() {
+                println!("Server GOT: {:?})", msg);
+
+                stream
+                    .send(Response::Greeting(name.to_owned()))
+                    .await
+                    .unwrap();
+            }
+        });
+    }
+}
+
+pub async fn client(name: &str) {
+    // Bind a server socket
+    let socket = TcpStream::connect("127.0.0.1:17653").await.unwrap();
+
+    // Delimit frames using a length header
+    let length_delimited = Framed::new(socket, LengthDelimitedCodec::new());
+
+    // Serialize and deserialize frames with JSON
+    let mut stream =
+        tokio_serde::Framed::new(length_delimited, Json::<Response, Request>::default());
+
+    // Send the value
+    stream
+        .send(Request::Hello(name.to_owned()))
+        .await
+        .unwrap();
+
+    if let Some(msg) = stream.try_next().await.unwrap() {
+        println!("Client GOT: {:?})", msg);
+    }
+}
+
+#[tokio::main]
+pub async fn main() {
+    let server = server("server");
+    let client_1 = client("client1");
+    let client_2 = client("client2");
+
+    futures::join!(server, client_1, client_2);
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,12 +27,20 @@
 //! * `tokio_util::codec::FramedWrite`
 //! * `tokio::net::TcpStream`
 //!
+//! Combining reading and writing a duplex (reading and writing) pipeline 
+//! looks like this:
+//!
+//! * `tokio_serde::Framed`
+//! * `tokio_util::codec::Framed`
+//! * `tokio::net::TcpStream`
+//!
 //! # Examples
 //!
 //! For an example, see how JSON support is implemented:
 //!
 //! * [server](https://github.com/carllerche/tokio-serde/blob/master/examples/server.rs)
 //! * [client](https://github.com/carllerche/tokio-serde/blob/master/examples/client.rs)
+//! * [client](https://github.com/carllerche/tokio-serde/blob/master/examples/duplex.rs)
 //!
 //! [serde]: https://serde.rs
 //! [serde-json]: https://github.com/serde-rs/json


### PR DESCRIPTION
I ran into issues trying to get a duplex pipeline working. It took me a few hours to figure out I should have been using `tokio_util::codec::Framed`. This PR attempts to add a duplex pipeline example showing:

- How to set up a duplex pipeline
- How to use none `SymmetricallyFramed` transport to serialize/deserialize to and from a `Request` and `Response` struct.
- How to send and receive after each other