### PR TITLE
Bump `rmp-serde` to version `1.1.1`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ pin-project = "1"
 serde = { version = "1", optional = true }
 bincode-crate = { package = "bincode", version = "1", optional = true }
 serde_json = { version = "1", optional = true }
-rmp-serde = { version = "0.15", optional = true }
+rmp-serde = { version = "1.1.1", optional = true }
 serde_cbor = { version = "0.11", optional = true }
 
 [dev-dependencies]


### PR DESCRIPTION
Hey there 👋 

this bumps the `rmp-serde` dependency to `1.1.1` due to https://security.snyk.io/vuln/SNYK-RUST-RMPSERDE-3369746