### PR TITLE
fix(deps): Correct minimal crate versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,12 +23,12 @@ libraries.
 
 [dependencies]
 bytes = "1.0"
-educe = { version = "0.4", optional = true, default-features = false }
+educe = { version = "0.4.1", optional = true, default-features = false }
 futures-core = "0.3"
 futures-sink = "0.3"
 pin-project = "1"
 serde = { version = "1", optional = true }
-bincode-crate = { package = "bincode", version = "1", optional = true }
+bincode-crate = { package = "bincode", version = "1.3", optional = true }
 serde_json = { version = "1", optional = true }
 rmp-serde = { version = "0.15", optional = true }
 serde_cbor = { version = "0.11", optional = true }


### PR DESCRIPTION
A few crates did not have their minimal version set correctly.  This bumps their versions.

Check with:

rm -f Cargo.lock
cargo +nightly check -Z minimal-versions --all-features