### PR TITLE
Remove educe dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,6 @@ libraries.
 
 [dependencies]
 bytes = "1.0"
-educe = { version = "0.4", optional = true, default-features = false }
 futures-core = "0.3"
 futures-sink = "0.3"
 pin-project = "1"
@@ -45,10 +44,10 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [features]
-bincode = ["educe/Debug", "serde", "bincode-crate"]
-json = ["educe/Debug", "educe/Default", "serde", "serde_json"]
-messagepack = ["educe/Debug", "educe/Default", "serde", "rmp-serde"]
-cbor = ["educe/Debug", "educe/Default", "serde", "serde_cbor"]
+bincode = ["serde", "bincode-crate"]
+json = ["serde", "serde_json"]
+messagepack = ["serde", "rmp-serde"]
+cbor = ["serde", "serde_cbor"]
 
 [[example]]
 name = "client"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -328,7 +328,6 @@ pub mod formats {
 
     use super::{Deserializer, Serializer};
     use bytes::{Bytes, BytesMut};
-    use educe::Educe;
     use serde::{Deserialize, Serialize};
     use std::{marker::PhantomData, pin::Pin};
 
@@ -340,18 +339,20 @@ pub mod formats {
 
         /// Bincode codec using [bincode](https://docs.rs/bincode) crate.
         #[cfg_attr(docsrs, doc(cfg(feature = "bincode")))]
-        #[derive(Educe)]
-        #[educe(Debug)]
         pub struct Bincode<Item, SinkItem, O = bincode_crate::DefaultOptions> {
-            #[educe(Debug(ignore))]
             options: O,
-            #[educe(Debug(ignore))]
             ghost: PhantomData<(Item, SinkItem)>,
+        }
+
+        impl<Item, SinkItem, O> std::fmt::Debug for Bincode<Item, SinkItem, O> {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                f.debug_struct(std::any::type_name::<Self>()).finish()
+            }
         }
 
         impl<Item, SinkItem> Default for Bincode<Item, SinkItem> {
             fn default() -> Self {
-                Bincode {
+                Self {
                     options: Default::default(),
                     ghost: PhantomData,
                 }
@@ -381,11 +382,10 @@ pub mod formats {
             type Error = io::Error;
 
             fn deserialize(self: Pin<&mut Self>, src: &BytesMut) -> Result<Item, Self::Error> {
-                Ok(self
-                    .options
+                self.options
                     .clone()
                     .deserialize(src)
-                    .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?)
+                    .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))
             }
         }
 
@@ -414,11 +414,20 @@ pub mod formats {
 
         /// JSON codec using [serde_json](https://docs.rs/serde_json) crate.
         #[cfg_attr(docsrs, doc(cfg(feature = "json")))]
-        #[derive(Educe)]
-        #[educe(Debug, Default)]
         pub struct Json<Item, SinkItem> {
-            #[educe(Debug(ignore), Default(expression = "PhantomData"))]
             ghost: PhantomData<(Item, SinkItem)>,
+        }
+
+        impl<Item, SinkItem> std::fmt::Debug for Json<Item, SinkItem> {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                f.debug_struct(std::any::type_name::<Self>()).finish()
+            }
+        }
+
+        impl<Item, SinkItem> Default for Json<Item, SinkItem> {
+            fn default() -> Self {
+                Self { ghost: PhantomData }
+            }
         }
 
         #[cfg_attr(docsrs, doc(cfg(feature = "json")))]
@@ -455,11 +464,20 @@ pub mod formats {
 
         /// MessagePack codec using [rmp-serde](https://docs.rs/rmp-serde) crate.
         #[cfg_attr(docsrs, doc(cfg(feature = "messagepack")))]
-        #[derive(Educe)]
-        #[educe(Debug, Default)]
         pub struct MessagePack<Item, SinkItem> {
-            #[educe(Debug(ignore), Default(expression = "PhantomData"))]
             ghost: PhantomData<(Item, SinkItem)>,
+        }
+
+        impl<Item, SinkItem> std::fmt::Debug for MessagePack<Item, SinkItem> {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                f.debug_struct(std::any::type_name::<Self>()).finish()
+            }
+        }
+
+        impl<Item, SinkItem> Default for MessagePack<Item, SinkItem> {
+            fn default() -> Self {
+                Self { ghost: PhantomData }
+            }
         }
 
         #[cfg_attr(docsrs, doc(cfg(feature = "messagepack")))]
@@ -472,8 +490,8 @@ pub mod formats {
             type Error = io::Error;
 
             fn deserialize(self: Pin<&mut Self>, src: &BytesMut) -> Result<Item, Self::Error> {
-                Ok(rmp_serde::from_read(std::io::Cursor::new(src).reader())
-                    .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?)
+                rmp_serde::from_read(std::io::Cursor::new(src).reader())
+                    .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))
             }
         }
 
@@ -498,11 +516,20 @@ pub mod formats {
 
         /// CBOR codec using [serde_cbor](https://docs.rs/serde_cbor) crate.
         #[cfg_attr(docsrs, doc(cfg(feature = "cbor")))]
-        #[derive(Educe)]
-        #[educe(Debug, Default)]
         pub struct Cbor<Item, SinkItem> {
-            #[educe(Debug(ignore), Default(expression = "PhantomData"))]
-            _mkr: PhantomData<(Item, SinkItem)>,
+            ghost: PhantomData<(Item, SinkItem)>,
+        }
+
+        impl<Item, SinkItem> std::fmt::Debug for Cbor<Item, SinkItem> {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                f.debug_struct(std::any::type_name::<Self>()).finish()
+            }
+        }
+
+        impl<Item, SinkItem> Default for Cbor<Item, SinkItem> {
+            fn default() -> Self {
+                Self { ghost: PhantomData }
+            }
         }
 
         #[cfg_attr(docsrs, doc(cfg(feature = "cbor")))]


### PR DESCRIPTION
educe is still on syn@1, which forces dependents to compile syn twice.
See https://github.com/magiclen/educe/issues/8.
