### PR TITLE
Use Into bounds instead of From

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -259,8 +259,8 @@ impl<Transport, Item, SinkItem, Codec> Framed<Transport, Item, SinkItem, Codec> 
 impl<Transport, Item, SinkItem, Codec> Stream for Framed<Transport, Item, SinkItem, Codec>
 where
     Transport: TryStream<Ok = BytesMut>,
-    Transport::Error: From<Codec::Error>,
-    BytesMut: From<Transport::Ok>,
+    Codec::Error: Into<Transport::Error>,
+    Transport::Ok: Into<BytesMut>,
     Codec: Deserializer<Item>,
 {
     type Item = Result<Item, Transport::Error>;
@@ -271,7 +271,8 @@ where
                 .as_mut()
                 .project()
                 .codec
-                .deserialize(&bytes?)?))),
+                .deserialize(&bytes?)
+                .map_err(Into::into)?))),
             None => Poll::Ready(None),
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -260,7 +260,6 @@ impl<Transport, Item, SinkItem, Codec> Stream for Framed<Transport, Item, SinkIt
 where
     Transport: TryStream<Ok = BytesMut>,
     Codec::Error: Into<Transport::Error>,
-    Transport::Ok: Into<BytesMut>,
     Codec: Deserializer<Item>,
 {
     type Item = Result<Item, Transport::Error>;


### PR DESCRIPTION
Explicit `From` bound makes some edge-cases of using this library problematic.